### PR TITLE
Add workaround for Unity issue 1253433.

### DIFF
--- a/Assets/AssetRegulationManager/Editor/Core/Model/AssetRegulations/AssetFilterImpl/ExtensionBasedAssetFilter.cs
+++ b/Assets/AssetRegulationManager/Editor/Core/Model/AssetRegulations/AssetFilterImpl/ExtensionBasedAssetFilter.cs
@@ -29,6 +29,14 @@ namespace AssetRegulationManager.Editor.Core.Model.AssetRegulations.AssetFilterI
 
         public void SetupForMatching()
         {
+            // In Unity2019.4.13 and earlier or Unity2020.1.0-2020.1.16, this field can be null when deserialization.
+            // This is a Unity's bug; issue id is 1253433.
+            // The following null check is a work-around for this.
+            if (_extensions == null)
+            {
+                _extensions = new List<string>();
+            }
+
             _extensions.Clear();
             foreach (var extension in _extension)
             {

--- a/Assets/AssetRegulationManager/Editor/Core/Model/AssetRegulations/AssetFilterImpl/ObjectBasedAssetFilter.cs
+++ b/Assets/AssetRegulationManager/Editor/Core/Model/AssetRegulations/AssetFilterImpl/ObjectBasedAssetFilter.cs
@@ -31,6 +31,14 @@ namespace AssetRegulationManager.Editor.Core.Model.AssetRegulations.AssetFilterI
 
         public void SetupForMatching()
         {
+            // In Unity2019.4.13 and earlier or Unity2020.1.0-2020.1.16, this field can be null when deserialization.
+            // This is a Unity's bug; issue id is 1253433.
+            // The following null check is a work-around for this.
+            if (_assetPaths == null)
+            {
+                _assetPaths = new List<string>();
+            }
+
             _assetPaths.Clear();
             foreach (var obj in _object)
             {

--- a/Assets/AssetRegulationManager/Editor/Core/Model/AssetRegulations/AssetFilterImpl/RegexBasedAssetFilter.cs
+++ b/Assets/AssetRegulationManager/Editor/Core/Model/AssetRegulations/AssetFilterImpl/RegexBasedAssetFilter.cs
@@ -29,6 +29,14 @@ namespace AssetRegulationManager.Editor.Core.Model.AssetRegulations.AssetFilterI
 
         public void SetupForMatching()
         {
+            // In Unity2019.4.13 and earlier or Unity2020.1.0-2020.1.16, this field can be null when deserialization.
+            // This is a Unity's bug; issue id is 1253433.
+            // The following null check is a work-around for this.
+            if (_regexes == null)
+            {
+                _regexes = new List<Regex>();
+            }
+
             _regexes.Clear();
             foreach (var assetPathRegex in _assetPathRegex)
             {


### PR DESCRIPTION
* Unity2019.4.13以前のバージョンとUnity2020.1.0〜2020.1.16において、以下のUnityのバグによりエラーが発生していたのでワークアラウンドを追加しました
* https://issuetracker.unity3d.com/issues/serializereference-non-serialized-fields-with-default-initializers-become-null-after-entering-playmode?_ga=2.131357900.2139814034.1641811070-1647536296.1628057211