### PR TITLE
Remove spaces in the Asset Regulation data file name created from Menu

### DIFF
--- a/Assets/AssetRegulationManager/Editor/Core/Data/AssetRegulationSetStore.cs
+++ b/Assets/AssetRegulationManager/Editor/Core/Data/AssetRegulationSetStore.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace AssetRegulationManager.Editor.Core.Data
 {
-    [CreateAssetMenu(fileName = "Asset Regulation Data", menuName = "Asset Regulation Data")]
+    [CreateAssetMenu(fileName = "AssetRegulationData", menuName = "Asset Regulation Data")]
     public sealed class AssetRegulationSetStore : ScriptableObject
     {
         [SerializeField] private AssetRegulationSet _set = new AssetRegulationSet();

--- a/Assets/AssetRegulationManager/Editor/Core/Tool/AssetRegulationEditor/AssetRegulationEditorListPanelController.cs
+++ b/Assets/AssetRegulationManager/Editor/Core/Tool/AssetRegulationEditor/AssetRegulationEditorListPanelController.cs
@@ -142,7 +142,7 @@ namespace AssetRegulationManager.Editor.Core.Tool.AssetRegulationEditor
             menu.AddSeparator(string.Empty);
             menu.AddItem(new GUIContent("Create New"), false, () =>
             {
-                var assetPath = EditorUtility.SaveFilePanelInProject("Save", "Asset Regulation Data", "asset", "");
+                var assetPath = EditorUtility.SaveFilePanelInProject("Save", "AssetRegulationData", "asset", "");
                 if (string.IsNullOrEmpty(assetPath))
                     return;
 


### PR DESCRIPTION
# fix
* Same as PR title

## Ideas for revisions

If whitespace is present when searching for file names or performing file operations from within a script, whitespace must be taken into account in the implementation.
However, looking at the library implementation, I could see no reason for spaces to be included.
Therefore, we proposed to remove the spaces for ease of use and submitted a PR.

Thank you for your time and consideration.

![image](https://user-images.githubusercontent.com/41669061/174352399-8dbba8e1-2327-4bf2-b117-2223a68df0a2.png)
